### PR TITLE
Change oj version to fix sensu installation using ruby 2.4

### DIFF
--- a/lib/sensu/json/oj.rb
+++ b/lib/sensu/json/oj.rb
@@ -1,4 +1,4 @@
-gem "oj", "2.14.6"
+gem "oj", "2.18.1"
 
 require "oj"
 

--- a/sensu-json.gemspec
+++ b/sensu-json.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   if RUBY_PLATFORM =~ /java/
     spec.add_dependency("jrjackson", "0.4.0")
   else
-    spec.add_dependency("oj", "2.14.6")
+    spec.add_dependency("oj", "2.18.1")
   end
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Change OJ version to fix Sensu installation using ruby 2.4.
Tests are passing.

The issue was opened on:
https://github.com/sensu/sensu/issues/1580